### PR TITLE
优化系统启动速度

### DIFF
--- a/IoTGateway/Startup.cs
+++ b/IoTGateway/Startup.cs
@@ -81,7 +81,7 @@ namespace IoTGateway
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IOptionsMonitor<Configs> configs, DeviceService deviceService, ModbusSlaveService modbusSlaveService)
+        public void Configure(IApplicationBuilder app, IOptionsMonitor<Configs> configs)
         {
             IconFontsHelper.GenerateIconFont();
             app.UseExceptionHandler(configs.CurrentValue.ErrorHandler); 


### PR DESCRIPTION
不要把DeviceService和ModbusSlaveService放在StartUp类的Configure方法参数里面，当系统内设备数量多的时候，
依赖注入对这两个service的构造函数的执行，会拖慢程序的启动

应该放在项目启动完成事件中，作为事件回调来执行

