### PR TITLE
驱动新增主动上报侦听事件

### DIFF
--- a/Plugins/Drivers/CNC.Fanuc.H/DeviceFanuc.cs
+++ b/Plugins/Drivers/CNC.Fanuc.H/DeviceFanuc.cs
@@ -13,6 +13,7 @@ namespace CNC.Fanuc.H
 
         public ILogger _logger { get; set; }
         private readonly string _device;
+        public event Func<object, DataReportEventArgs, Task>? OnDataReceived;
 
         #region 配置参数
 

--- a/Plugins/Drivers/CNC.Fanuc/DeviceFanuc.cs
+++ b/Plugins/Drivers/CNC.Fanuc/DeviceFanuc.cs
@@ -12,6 +12,7 @@ namespace CNC.Fanuc
 
         public ILogger _logger { get; set; }
         private readonly string _device;
+        public event Func<object, DataReportEventArgs, Task>? OnDataReceived;
 
         #region 配置参数
 

--- a/Plugins/Drivers/CNC.MTConnect/DeviceMTClient.cs
+++ b/Plugins/Drivers/CNC.MTConnect/DeviceMTClient.cs
@@ -11,6 +11,7 @@ namespace CNC.MTConnect
         private EntityClient? _mClient;
         public ILogger _logger { get; set; }
         private readonly string _device;
+        public event Func<object, DataReportEventArgs, Task>? OnDataReceived;
 
         #region 配置参数
 

--- a/Plugins/Drivers/Mock.TcpClient/DeviceTcpClient.cs
+++ b/Plugins/Drivers/Mock.TcpClient/DeviceTcpClient.cs
@@ -93,7 +93,30 @@ namespace Mock.TcpClient
         {
             //如果收到的数据校验正确，则放在内存中
             if (e.Data.Length == 8 && e.Data[0] == 0x08)
-                _latestRcvData = e.Data;
+                _latestRcvData = e.Data
+                
+                var dataArgs = new DataReportEventArgs
+                {
+                    DeviceId = DeviceId,
+                    VariableName = "接收到数据",
+                    Address = "",
+                    Value = e.Data,
+                    Timestamp = DateTime.Now,
+                    StatusType = VaribaleStatusTypeEnum.Good,
+                    Message = ""
+                };
+                // 在后台线程中异步处理，避免阻塞调用方
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await OnDataReceived.Invoke(this, dataArgs);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, $"触发式数据上报失败: {dataArgs.VariableName}");
+                    }
+                });
         }
 
         /// <summary>

--- a/Plugins/Drivers/Mock.TcpClient/DeviceTcpClient.cs
+++ b/Plugins/Drivers/Mock.TcpClient/DeviceTcpClient.cs
@@ -20,6 +20,7 @@ namespace Mock.TcpClient
 
         public ILogger _logger { get; set; }
         private readonly string _device;
+        public event Func<object, DataReportEventArgs, Task>? OnDataReceived;
 
         #region 配置参数
 

--- a/Plugins/Drivers/OPC.DaClient/DeviceDaClient.cs
+++ b/Plugins/Drivers/OPC.DaClient/DeviceDaClient.cs
@@ -12,6 +12,7 @@ namespace OPC.DaClient
 
         public ILogger _logger { get; set; }
         private readonly string _device;
+        public event Func<object, DataReportEventArgs, Task>? OnDataReceived;
 
         #region 配置参数
 

--- a/Plugins/Drivers/OPC.UaClient/DeviceUaClient.cs
+++ b/Plugins/Drivers/OPC.UaClient/DeviceUaClient.cs
@@ -12,6 +12,7 @@ namespace OPC.UaClient
         private OpcUaClientHelper? _opcUaClient;
         public ILogger _logger { get; set; }
         private readonly string _device;
+        public event Func<object, DataReportEventArgs, Task>? OnDataReceived;
 
         #region 配置参数
 

--- a/Plugins/Drivers/Other.Toledo/DeviceToledo.cs
+++ b/Plugins/Drivers/Other.Toledo/DeviceToledo.cs
@@ -25,6 +25,7 @@ namespace Other.Toledo
 
         public ILogger _logger { get; set; }
         private readonly string _device;
+        public event Func<object, DataReportEventArgs, Task>? OnDataReceived;
 
         #region 配置参数
 

--- a/Plugins/Drivers/PLC.AllenBradley/DeviceAllenBradley.cs
+++ b/Plugins/Drivers/PLC.AllenBradley/DeviceAllenBradley.cs
@@ -12,6 +12,7 @@ namespace PLC.AllenBradley
 
         public ILogger _logger { get; set; }
         private readonly string _device;
+         public event Func<object, DataReportEventArgs, Task>? OnDataReceived;
 
         #region 配置参数
 

--- a/Plugins/Drivers/PLC.MelsecMc/DeviceMelsecMc.cs
+++ b/Plugins/Drivers/PLC.MelsecMc/DeviceMelsecMc.cs
@@ -15,6 +15,7 @@ namespace PLC.MelsecMc
 
         public ILogger _logger { get; set; }
         private readonly string _device;
+        public event Func<object, DataReportEventArgs, Task>? OnDataReceived;
 
         #region 配置参数
 

--- a/Plugins/Drivers/PLC.ModBusMaster/DeviceModBusMaster.cs
+++ b/Plugins/Drivers/PLC.ModBusMaster/DeviceModBusMaster.cs
@@ -27,6 +27,7 @@ namespace PLC.ModBusMaster
 
         public ILogger _logger { get; set; }
         private readonly string _device;
+         public event Func<object, DataReportEventArgs, Task>? OnDataReceived;
 
         #region 配置参数
 

--- a/Plugins/Drivers/PLC.OmronFins/DeviceOmronFins.cs
+++ b/Plugins/Drivers/PLC.OmronFins/DeviceOmronFins.cs
@@ -11,6 +11,7 @@ namespace PLC.OmronFins
         private OmronFinsClient? _plc;
         public ILogger _logger { get; set; }
         private readonly string _device;
+         public event Func<object, DataReportEventArgs, Task>? OnDataReceived;
 
         #region 配置参数
 

--- a/Plugins/Drivers/PLC.SiemensS7/DeviceSiemensS7.cs
+++ b/Plugins/Drivers/PLC.SiemensS7/DeviceSiemensS7.cs
@@ -19,6 +19,7 @@ namespace PLC.SiemensS7
 
         public ILogger _logger { get; set; }
         private readonly string _device;
+         public event Func<object, DataReportEventArgs, Task>? OnDataReceived;
 
         #region 配置参数
 

--- a/Plugins/Plugin/DeviceThread.cs
+++ b/Plugins/Plugin/DeviceThread.cs
@@ -82,129 +82,129 @@ namespace Plugin
         }
 
         /// <summary>
-/// 处理驱动主动上报的数据
-/// </summary>
-/// <param name="sender"></param>
-/// <param name="e"></param>
-private async Task OnDriverDataReceived(object sender, DataReportEventArgs e)
-{
-    try
-    {
-        // 根据变量名或地址查找对应的DeviceVariable
-        var deviceVariable = Device.DeviceVariables?.FirstOrDefault(v => 
-            v.Name == e.VariableName || 
-            v.DeviceAddress == e.Address ||
-            (!string.IsNullOrEmpty(e.Address) && v.DeviceAddress == e.Address));
-
-        if (deviceVariable == null)
+        /// 处理驱动主动上报的数据
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private async Task OnDriverDataReceived(object sender, DataReportEventArgs e)
         {
-            _logger.LogWarning($"未找到对应的设备变量: {e.VariableName}, 地址: {e.Address}");
-            return;
-        }
-
-        // 创建返回值模型
-        var ret = new DriverReturnValueModel
-        {
-            Value = e.Value,
-            StatusType = e.StatusType,
-            Timestamp = e.Timestamp,
-            Message = e.Message,
-            VarId = deviceVariable.ID
-        };
-
-        // 将原始值加入队列（保存最近3次）
-        deviceVariable.EnqueueVariable(ret.Value);
-
-        // 表达式计算（如果配置了）
-        if (ret.StatusType == VaribaleStatusTypeEnum.Good && !string.IsNullOrWhiteSpace(deviceVariable.Expressions?.Trim()))
-        {
-            var expressionText = DealMysqlStr(deviceVariable.Expressions)
-                .Replace("raw",
-                    deviceVariable.Values[0] is bool
-                        ? $"Convert.ToBoolean(\"{deviceVariable.Values[0]}\")"
-                        : deviceVariable.Values[0]?.ToString())
-                .Replace("$v",
-                    deviceVariable.Values[0] is bool
-                        ? $"Convert.ToBoolean(\"{deviceVariable.Values[0]}\")"
-                        : deviceVariable.Values[0]?.ToString())
-                .Replace("$pv",
-                    deviceVariable.Values[1] is bool
-                        ? $"Convert.ToBoolean(\"{deviceVariable.Values[1]}\")"
-                        : deviceVariable.Values[1]?.ToString())
-                .Replace("$ppv",
-                    deviceVariable.Values[2] is bool
-                        ? $"Convert.ToBoolean(\"{deviceVariable.Values[2]}\")"
-                        : deviceVariable.Values[2]?.ToString());
-
             try
             {
-                ret.CookedValue = _interpreter!.Eval(expressionText);
+                // 根据变量名或地址查找对应的DeviceVariable
+                var deviceVariable = Device.DeviceVariables?.FirstOrDefault(v => 
+                    v.Name == e.VariableName || 
+                    v.DeviceAddress == e.Address ||
+                    (!string.IsNullOrEmpty(e.Address) && v.DeviceAddress == e.Address));
+        
+                if (deviceVariable == null)
+                {
+                    _logger.LogWarning($"未找到对应的设备变量: {e.VariableName}, 地址: {e.Address}");
+                    return;
+                }
+        
+                // 创建返回值模型
+                var ret = new DriverReturnValueModel
+                {
+                    Value = e.Value,
+                    StatusType = e.StatusType,
+                    Timestamp = e.Timestamp,
+                    Message = e.Message,
+                    VarId = deviceVariable.ID
+                };
+        
+                // 将原始值加入队列（保存最近3次）
+                deviceVariable.EnqueueVariable(ret.Value);
+        
+                // 表达式计算（如果配置了）
+                if (ret.StatusType == VaribaleStatusTypeEnum.Good && !string.IsNullOrWhiteSpace(deviceVariable.Expressions?.Trim()))
+                {
+                    var expressionText = DealMysqlStr(deviceVariable.Expressions)
+                        .Replace("raw",
+                            deviceVariable.Values[0] is bool
+                                ? $"Convert.ToBoolean(\"{deviceVariable.Values[0]}\")"
+                                : deviceVariable.Values[0]?.ToString())
+                        .Replace("$v",
+                            deviceVariable.Values[0] is bool
+                                ? $"Convert.ToBoolean(\"{deviceVariable.Values[0]}\")"
+                                : deviceVariable.Values[0]?.ToString())
+                        .Replace("$pv",
+                            deviceVariable.Values[1] is bool
+                                ? $"Convert.ToBoolean(\"{deviceVariable.Values[1]}\")"
+                                : deviceVariable.Values[1]?.ToString())
+                        .Replace("$ppv",
+                            deviceVariable.Values[2] is bool
+                                ? $"Convert.ToBoolean(\"{deviceVariable.Values[2]}\")"
+                                : deviceVariable.Values[2]?.ToString());
+        
+                    try
+                    {
+                        ret.CookedValue = _interpreter!.Eval(expressionText);
+                    }
+                    catch (Exception ex)
+                    {
+                        ret.Message = $"表达式错误：{expressionText}";
+                        ret.StatusType = VaribaleStatusTypeEnum.ExpressionError;
+                        _logger.LogError(ex, $"表达式计算失败: {expressionText}");
+                    }
+                }
+                else
+                {
+                    ret.CookedValue = ret.Value;
+                }
+        
+                // 将计算后的值加入队列
+                deviceVariable.EnqueueCookedVariable(ret.CookedValue);
+        
+                // 更新设备变量的状态
+                deviceVariable.Value = ret.Value;
+                deviceVariable.CookedValue = ret.CookedValue;
+                deviceVariable.StatusType = ret.StatusType;
+                deviceVariable.Timestamp = ret.Timestamp;
+                deviceVariable.Message = ret.Message;
+        
+                // 发布到MQTT（用于前端展示）
+                if (JsonConvert.SerializeObject(deviceVariable.Values[1]) != JsonConvert.SerializeObject(deviceVariable.Values[0]) ||
+                    JsonConvert.SerializeObject(deviceVariable.CookedValues[1]) != JsonConvert.SerializeObject(deviceVariable.CookedValues[0]))
+                {
+                    var msgInternal = new InjectedMqttApplicationMessage(
+                        new MqttApplicationMessage()
+                        {
+                            Topic = $"internal/v1/gateway/telemetry/{Device.DeviceName}/{deviceVariable.Name}",
+                            PayloadSegment = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(ret))
+                        });
+                    _mqttServer.InjectApplicationMessage(msgInternal);
+                }
+        
+                // 如果变量配置为上传，则发布遥测数据
+                if (deviceVariable.IsUpload && ret.StatusType == VaribaleStatusTypeEnum.Good)
+                {
+                    var deviceName = string.IsNullOrWhiteSpace(deviceVariable.Alias) ? Device.DeviceName : deviceVariable.Alias;
+                    var sendModel = new Dictionary<string, List<PayLoad>>
+                    {
+                        {
+                            deviceName,
+                            new List<PayLoad>
+                            {
+                                new PayLoad
+                                {
+                                    Values = new Dictionary<string, object> { { deviceVariable.Name, ret.CookedValue } },
+                                    TS = (long)(DateTime.UtcNow - _tsStartDt).TotalMilliseconds,
+                                    DeviceStatus = DeviceStatusTypeEnum.Good
+                                }
+                            }
+                        }
+                    };
+        
+                    await _messageService.PublishTelemetryAsync(deviceName, Device, sendModel);
+                }
+        
+                _logger.LogDebug($"处理驱动上报数据: {deviceVariable.Name} = {ret.CookedValue}");
             }
             catch (Exception ex)
             {
-                ret.Message = $"表达式错误：{expressionText}";
-                ret.StatusType = VaribaleStatusTypeEnum.ExpressionError;
-                _logger.LogError(ex, $"表达式计算失败: {expressionText}");
+                _logger.LogError(ex, $"处理驱动上报数据失败: {e.VariableName}");
             }
         }
-        else
-        {
-            ret.CookedValue = ret.Value;
-        }
-
-        // 将计算后的值加入队列
-        deviceVariable.EnqueueCookedVariable(ret.CookedValue);
-
-        // 更新设备变量的状态
-        deviceVariable.Value = ret.Value;
-        deviceVariable.CookedValue = ret.CookedValue;
-        deviceVariable.StatusType = ret.StatusType;
-        deviceVariable.Timestamp = ret.Timestamp;
-        deviceVariable.Message = ret.Message;
-
-        // 发布到MQTT（用于前端展示）
-        if (JsonConvert.SerializeObject(deviceVariable.Values[1]) != JsonConvert.SerializeObject(deviceVariable.Values[0]) ||
-            JsonConvert.SerializeObject(deviceVariable.CookedValues[1]) != JsonConvert.SerializeObject(deviceVariable.CookedValues[0]))
-        {
-            var msgInternal = new InjectedMqttApplicationMessage(
-                new MqttApplicationMessage()
-                {
-                    Topic = $"internal/v1/gateway/telemetry/{Device.DeviceName}/{deviceVariable.Name}",
-                    PayloadSegment = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(ret))
-                });
-            _mqttServer.InjectApplicationMessage(msgInternal);
-        }
-
-        // 如果变量配置为上传，则发布遥测数据
-        if (deviceVariable.IsUpload && ret.StatusType == VaribaleStatusTypeEnum.Good)
-        {
-            var deviceName = string.IsNullOrWhiteSpace(deviceVariable.Alias) ? Device.DeviceName : deviceVariable.Alias;
-            var sendModel = new Dictionary<string, List<PayLoad>>
-            {
-                {
-                    deviceName,
-                    new List<PayLoad>
-                    {
-                        new PayLoad
-                        {
-                            Values = new Dictionary<string, object> { { deviceVariable.Name, ret.CookedValue } },
-                            TS = (long)(DateTime.UtcNow - _tsStartDt).TotalMilliseconds,
-                            DeviceStatus = DeviceStatusTypeEnum.Good
-                        }
-                    }
-                }
-            };
-
-            await _messageService.PublishTelemetryAsync(deviceName, Device, sendModel);
-        }
-
-        _logger.LogDebug($"处理驱动上报数据: {deviceVariable.Name} = {ret.CookedValue}");
-    }
-    catch (Exception ex)
-    {
-        _logger.LogError(ex, $"处理驱动上报数据失败: {e.VariableName}");
-    }
-}
 
         private async Task CreateThreadAsync(CancellationToken token)
         {

--- a/Plugins/PluginInterface/IDriver.cs
+++ b/Plugins/PluginInterface/IDriver.cs
@@ -1,7 +1,19 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace PluginInterface
 {
+    // 数据上报事件参数
+    public class DataReportEventArgs : EventArgs
+    {
+        public string DeviceId { get; set; } = string.Empty;
+        public string VariableName { get; set; } = string.Empty;
+        public object? Value { get; set; }
+        public DateTime Timestamp { get; set; } = DateTime.Now;
+        public VaribaleStatusTypeEnum StatusType { get; set; } = VaribaleStatusTypeEnum.Good;
+        public string Message { get; set; } = string.Empty;
+        public string? Address { get; set; }
+    }
+
     public interface IDriver : IDisposable
     {
         public string DeviceId { get; }
@@ -10,6 +22,9 @@ namespace PluginInterface
         public uint MinPeriod { get; }
 
         public ILogger _logger { get; set; }
+
+        // 异步数据上报事件
+        public event Func<object, DataReportEventArgs, Task>? OnDataReceived;
 
         public bool Connect();
 


### PR DESCRIPTION
解决问题：
解决设备整体采集周期长，部分点位实时性要求高（如设备运行状态变更，设备报警等）

使用说明：
用户需添加对应名称的点位（可以考虑配置空的读取方法，添加时选择方法，再编辑把方法清空【bug，可以减少调采集方法】）
驱动实现时，参照该方法【Mock.TcpClient有示例】，传递对应的点位数据给到采集线程；采集线程匹配VariableName进行数据更新；
            var dataArgs = new DataReportEventArgs
            {
                DeviceId = DeviceId,
                VariableName = "连接状态",
                Address = "",
                Value = connectState.ToString(),
                Timestamp = DateTime.Now,
                StatusType = VaribaleStatusTypeEnum.Good,
                Message = ""
            };
            // 在后台线程中异步处理，避免阻塞调用方
            _ = Task.Run(async () =>
            {
                try
                {
                    await OnDataReceived.Invoke(this, dataArgs);
                }
                catch (Exception ex)
                {
                    _logger.LogError(ex, $"触发式数据上报失败: {dataArgs.VariableName}");
                }
            });

PS：未进行细致测试，应该不会影响性能吧^_^
